### PR TITLE
Fix foreign key constraint violation in seed script

### DIFF
--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -17,8 +17,8 @@ async function seed() {
   const db = drizzle(client, { schema });
 
   await db.delete(submissions).execute();
-
   await db.delete(builders).execute();
+
   db.insert(builders)
     .values([
       { id: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", role: "admin" },


### PR DESCRIPTION
This PR addresses the issue where re-seeding the database fails due to foreign key constraint violations. The fix ensures that the seed script can be run multiple times without errors.

Changes made:
- Reordered delete operations in seed.ts to remove submissions before builders


Fixes #16 


https://github.com/user-attachments/assets/e1ba32fe-c743-40d7-a67c-302d003858a7

