### PR TITLE
Exclude external links from triggering progress bar

### DIFF
--- a/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
+++ b/packages/nextjs/components/scaffold-eth/ProgressBar.tsx
@@ -45,9 +45,10 @@ export function ProgressBar() {
     NProgress.configure({ showSpinner: false });
 
     const handleAnchorClick = (event: MouseEvent) => {
-      const targetUrl = (event.currentTarget as HTMLAnchorElement).href;
+      const anchor = event.currentTarget as HTMLAnchorElement;
+      const targetUrl = anchor.href;
       const currentUrl = location.href;
-      if (targetUrl !== currentUrl) {
+      if (targetUrl !== currentUrl && !anchor.target) {
         NProgress.start();
       }
     };


### PR DESCRIPTION
### This PR:

-> Modifies the nprogress bar so that it only forks for non external links.

Here is the change

![image](https://github.com/user-attachments/assets/b1a945a8-9819-413c-8ee0-1716b2c1ef15)

Here is a test of the changes

https://github.com/user-attachments/assets/e4110fb8-e79c-470e-aeaf-a6a49a59c16f

