### PR TITLE
Switch to migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Visit your app on: `http://localhost:3000`.
 
 We are using Drizzle with Postgres. You can run `drizzle-kit` from the root with `yarn drizzle-kit`
 
+- To sync your database run `yarn drizzle-kit migrate`
+- Tweak `seed.js` if needed + run `yarn seed` (will delete existing data)
+
 To iterate on the database:
 
 - Tweak the schema in `schema.ts`
-- Run `yarn drizzle-kit push` to apply the changes.
-- Tweak `seed.js` if needed + run `yarn seed` (will delete existing data)
-- You can explore the database with `yarn drizzle-kit studio`
+- `yarn drizzle-kit generate` to create migration files (or use `yarn drizzle-kit push` if you are just tinkering)
 
-After the initial iterations, we can start using migrations (`yarn drizzle-kit generate` & `yarn drizzle-kit migrate`)
-
+You can explore the database with `yarn drizzle-kit studio`

--- a/packages/nextjs/services/database/migrations/0000_easy_the_initiative.sql
+++ b/packages/nextjs/services/database/migrations/0000_easy_the_initiative.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS "builders" (
+	"id" varchar(256) PRIMARY KEY NOT NULL,
+	"role" varchar(256) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "comments" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"submission_id" integer NOT NULL,
+	"builder_id" varchar(256) NOT NULL,
+	"comment" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "submissions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"description" text NOT NULL,
+	"telegram" varchar(256),
+	"link_to_repository" varchar(256) NOT NULL,
+	"link_to_video" varchar(256) NOT NULL,
+	"feedback" text,
+	"submission_timestamp" timestamp DEFAULT now() NOT NULL,
+	"builder_id" varchar(256) NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "votes" (
+	"submission_id" integer NOT NULL,
+	"builder_id" varchar(256) NOT NULL,
+	"score" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "votes_submission_id_builder_id_pk" PRIMARY KEY("submission_id","builder_id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "comments" ADD CONSTRAINT "comments_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "comments" ADD CONSTRAINT "comments_builder_id_builders_id_fk" FOREIGN KEY ("builder_id") REFERENCES "public"."builders"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "submissions" ADD CONSTRAINT "submissions_builder_id_builders_id_fk" FOREIGN KEY ("builder_id") REFERENCES "public"."builders"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "votes" ADD CONSTRAINT "votes_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "votes" ADD CONSTRAINT "votes_builder_id_builders_id_fk" FOREIGN KEY ("builder_id") REFERENCES "public"."builders"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/nextjs/services/database/migrations/meta/0000_snapshot.json
+++ b/packages/nextjs/services/database/migrations/meta/0000_snapshot.json
@@ -1,0 +1,255 @@
+{
+  "id": "80443e7a-1d64-4aaa-b15a-c72ed19ef3b2",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.builders": {
+      "name": "builders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "builder_id": {
+          "name": "builder_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_submission_id_submissions_id_fk": {
+          "name": "comments_submission_id_submissions_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_builder_id_builders_id_fk": {
+          "name": "comments_builder_id_builders_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "builders",
+          "columnsFrom": [
+            "builder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_to_repository": {
+          "name": "link_to_repository",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_to_video": {
+          "name": "link_to_video",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_timestamp": {
+          "name": "submission_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "builder_id": {
+          "name": "builder_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "submissions_builder_id_builders_id_fk": {
+          "name": "submissions_builder_id_builders_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "builders",
+          "columnsFrom": [
+            "builder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "submission_id": {
+          "name": "submission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "builder_id": {
+          "name": "builder_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_submission_id_submissions_id_fk": {
+          "name": "votes_submission_id_submissions_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "votes_builder_id_builders_id_fk": {
+          "name": "votes_builder_id_builders_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "builders",
+          "columnsFrom": [
+            "builder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_submission_id_builder_id_pk": {
+          "name": "votes_submission_id_builder_id_pk",
+          "columns": [
+            "submission_id",
+            "builder_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/nextjs/services/database/migrations/meta/_journal.json
+++ b/packages/nextjs/services/database/migrations/meta/_journal.json
@@ -1,0 +1,14 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1724237255094,
+      "tag": "0000_easy_the_initiative",
+      "breakpoints": true
+    }
+  ]
+}
+


### PR DESCRIPTION
No rush on this, just want to open the conversation... Thinking about future projects.

-----

Now that we have a live database, just wanted to see what it looked like to switch to a migration model (instead of just `drizzle-kit push` which is meant for prototyping).

A few nice to haves (ToDO for future PRs?):
- Seed: don't run if it's a PROD database (to avoid deleting tables). Maybe we can have a `--force` flag. I believe Shiv implemented this on grants.
- Integrate this on the Vercel CI/CD workflow (run migrations on deploy for the main branch). We might need a staging database? So the preview deployments don't run the migrations on the live database. 

One thing that I don't like is that you always get this message after `drizzle-kit migrate`

![image](https://github.com/user-attachments/assets/e44305f9-7d9a-4e04-a8d6-b85fe766a96c)

Doesn't show which migrations were applied and/or if there is no pending migrations. I think Prisma does this better.

