### PR TITLE
guard seed

### DIFF
--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -7,37 +7,18 @@ import { Client } from "pg";
 
 dotenv.config({ path: path.resolve(__dirname, "../../.env.development") });
 
-const MAX_SUBMISSIONS_BEFORE_FORCE = 20;
-
 const client = new Client({
   connectionString: process.env.POSTGRES_URL,
 });
 
-// TODO: protect, only for dev.
 async function seed() {
   if (!process.env.POSTGRES_URL?.includes("localhost")) {
     console.error("Cannot seed production database");
     process.exit(1);
   }
 
-  const args = process.argv.slice(2);
-  const flags = args.filter(arg => arg.startsWith("--"));
-  const isForce = flags.includes("--force");
-
   await client.connect();
   const db = drizzle(client, { schema });
-
-  const submissionsCount = await db.query.submissions.findMany({
-    columns: {
-      id: true,
-    },
-    limit: 21,
-  });
-
-  if (submissionsCount.length > MAX_SUBMISSIONS_BEFORE_FORCE && !isForce) {
-    console.error("Database has more than 20 submission, use --force flag to reseed");
-    process.exit(1);
-  }
 
   await db.delete(comments).execute();
   await db.delete(votes).execute();

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -7,12 +7,12 @@ import { Client } from "pg";
 
 dotenv.config({ path: path.resolve(__dirname, "../../.env.development") });
 
+const client = new Client({
+  connectionString: process.env.POSTGRES_URL,
+});
+
 // TODO: protect, only for dev.
 async function seed() {
-  const client = new Client({
-    connectionString: process.env.POSTGRES_URL,
-  });
-
   await client.connect();
   const db = drizzle(client, { schema });
 
@@ -84,6 +84,7 @@ seed()
   .catch(error => {
     console.error("Error seeding database:", error);
   })
-  .finally(() => {
+  .finally(async () => {
+    await client.end();
     process.exit();
   });

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -7,7 +7,6 @@ import { Client } from "pg";
 
 dotenv.config({ path: path.resolve(__dirname, "../../.env.development") });
 
-const VERCEL_DB_STRING = "verceldb";
 const MAX_SUBMISSIONS_BEFORE_FORCE = 20;
 
 const client = new Client({
@@ -16,7 +15,7 @@ const client = new Client({
 
 // TODO: protect, only for dev.
 async function seed() {
-  if (process.env.POSTGRES_URL?.includes(VERCEL_DB_STRING)) {
+  if (!process.env.POSTGRES_URL?.includes("localhost")) {
     console.error("Cannot seed production database");
     process.exit(1);
   }

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -7,14 +7,38 @@ import { Client } from "pg";
 
 dotenv.config({ path: path.resolve(__dirname, "../../.env.development") });
 
+const VERCEL_DB_STRING = "verceldb";
+const MAX_SUBMISSIONS_BEFORE_FORCE = 20;
+
 const client = new Client({
   connectionString: process.env.POSTGRES_URL,
 });
 
 // TODO: protect, only for dev.
 async function seed() {
+  if (process.env.POSTGRES_URL?.includes(VERCEL_DB_STRING)) {
+    console.error("Cannot seed production database");
+    process.exit(1);
+  }
+
+  const args = process.argv.slice(2);
+  const flags = args.filter(arg => arg.startsWith("--"));
+  const isForce = flags.includes("--force");
+
   await client.connect();
   const db = drizzle(client, { schema });
+
+  const submissionsCount = await db.query.submissions.findMany({
+    columns: {
+      id: true,
+    },
+    limit: 21,
+  });
+
+  if (submissionsCount.length > MAX_SUBMISSIONS_BEFORE_FORCE && !isForce) {
+    console.error("Database has more than 20 submission, use --force flag to reseed");
+    process.exit(1);
+  }
 
   await db.delete(comments).execute();
   await db.delete(votes).execute();


### PR DESCRIPTION
### Description: 

- added a naive check: if the Postgres URL contains the string "verceldb" (which is typically present in Vercel's Postgres databases), then seed  will always fail.

- Another check is we check if submissions length is > 20 then we fail and this check can be bypassed using `--force` flag

I think in future when we implement preview at that time 1st check can be removed manually while doing 1 time seed? 