### PR TITLE
style: Style admin rating stars. Add count to tabs.

### DIFF
--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -84,7 +84,7 @@ export const SubmissionCard = ({ submission }: { submission: Submission }) => {
   const telegramUser = submission.telegram?.replace("@", "");
 
   return (
-    <div key={submission.id} className="card bg-secondary text-secondary-content border border-primary rounded-none">
+    <div key={submission.id} className="card bg-base-200 text-secondary-content border border-gray-300 rounded-none">
       <div className="card-body p-4">
         <h2 className="card-title mb-3 xl:text-2xl">{submission.title}</h2>
         <div className="flex flex-wrap justify-between items-center gap-4">

--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -177,7 +177,7 @@ export const SubmissionCard = ({ submission }: { submission: Submission }) => {
               <input
                 type="radio"
                 name={`rating_${submission.id}`}
-                className="mask mask-star-2 star bg-gray-400 peer peer-hover:bg-gray-400"
+                className="mask mask-star-2 star bg-amber-500 peer peer-hover:bg-amber-400"
                 title={(i + 1).toString()}
                 checked={score === i + 1}
                 key={i}

--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { SubmissionComments } from "./SubmissionComments";
+import "./submission-rating.css";
 import { useMutation } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
 import { Address } from "~~/components/scaffold-eth";
@@ -176,7 +177,7 @@ export const SubmissionCard = ({ submission }: { submission: Submission }) => {
               <input
                 type="radio"
                 name={`rating_${submission.id}`}
-                className="mask mask-star"
+                className="mask mask-star-2 star bg-gray-400 peer peer-hover:bg-gray-400"
                 title={(i + 1).toString()}
                 checked={score === i + 1}
                 key={i}

--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -163,7 +163,7 @@ export const SubmissionCard = ({ submission }: { submission: Submission }) => {
         <p>{submission.description}</p>
         {submission.feedback && <p>Extensions feedback: {submission.feedback}</p>}
 
-        <div className="flex items-center">
+        <div className="flex items-center justify-between">
           <div className="rating flex items-center">
             <input
               type="radio"
@@ -184,19 +184,23 @@ export const SubmissionCard = ({ submission }: { submission: Submission }) => {
                 onChange={() => vote(i + 1)}
               />
             ))}
-            {score > 0 && (
-              <label className="cursor-pointer underline text-sm ml-3" htmlFor={`rating_${submission.id}_0`}>
-                Clear
-              </label>
-            )}
           </div>
+          {score > 0 && (
+            <label
+              className="cursor-pointer underline text-sm ml-3 hover:no-underline"
+              htmlFor={`rating_${submission.id}_0`}
+            >
+              Clear
+            </label>
+          )}
         </div>
 
-        <SubmissionComments submission={submission} />
-
-        <div className="badge badge-accent flex flex-col p-8 border border-accent-content">
-          <div className="text-2xl font-bold">{scoreAvg}</div>
-          <div>{submission.votes.length} votes</div>
+        <div className="mt-4 flex items-center justify-between">
+          <div className="badge badge-accent flex flex-col shrink-0 p-8 border border-accent-content">
+            <div className="text-2xl font-bold">{scoreAvg}</div>
+            <div>{submission.votes.length} votes</div>
+          </div>
+          <SubmissionComments submission={submission} />
         </div>
       </div>
     </div>

--- a/packages/nextjs/app/admin/_components/SubmissionComments.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionComments.tsx
@@ -47,7 +47,7 @@ export const SubmissionComments = ({ submission }: { submission: Submission }) =
   };
 
   return (
-    <div className="drawer drawer-end">
+    <div className="drawer drawer-end w-auto">
       <input id={`comments_drawer_${submission.id}`} type="checkbox" className="drawer-toggle" />
       <div className="drawer-content">
         <label

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -28,8 +28,8 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
     },
   );
 
-  const votedLabel = connectedAddress ? `Voted (${voted.length})` : "Voted (0)";
-  const notVotedLabel = connectedAddress ? `Not Voted (${notVoted.length})` : "Not Voted (0)";
+  const votedLabel = connectedAddress ? `Voted (${voted.length})` : "Voted (-)";
+  const notVotedLabel = connectedAddress ? `Not Voted (${notVoted.length})` : "Not Voted (-)";
 
   return (
     <div className="max-w-7xl container mx-auto px-6">

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -28,6 +28,9 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
     },
   );
 
+  const votedLabel = connectedAddress ? `Voted (${voted.length})` : "Voted (0)";
+  const notVotedLabel = connectedAddress ? `Not Voted (${notVoted.length})` : "Not Voted (0)";
+
   return (
     <div className="max-w-7xl container mx-auto px-6">
       <div role="tablist" className="tabs tabs-bordered tabs-lg">
@@ -36,7 +39,7 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           name="submission_tabs"
           role="tab"
           className="tab whitespace-nowrap"
-          aria-label="Not Voted"
+          aria-label={notVotedLabel}
           defaultChecked
         />
         <div role="tabpanel" className="tab-content py-6">
@@ -55,7 +58,13 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           </div>
         </div>
 
-        <input type="radio" name="submission_tabs" role="tab" className="tab whitespace-nowrap" aria-label="Voted" />
+        <input
+          type="radio"
+          name="submission_tabs"
+          role="tab"
+          className="tab whitespace-nowrap"
+          aria-label={votedLabel}
+        />
         <div role="tabpanel" className="tab-content py-6">
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
             {voted.map(submission => {

--- a/packages/nextjs/app/admin/_components/submission-rating.css
+++ b/packages/nextjs/app/admin/_components/submission-rating.css
@@ -1,0 +1,20 @@
+.rating input:checked ~ input,
+.rating input[aria-checked="true"] ~ input {
+    --tw-bg-opacity: 1;
+}
+
+.rating:hover .star {
+    @apply bg-amber-500;
+}
+
+.rating:hover .star.peer:hover ~ .peer-hover\:bg-gray-400 {
+    @apply bg-gray-400;
+}
+
+.rating input[type=radio]:checked {
+    @apply bg-amber-500;
+}
+
+.rating *:has(+ input[type=radio]:checked) {
+    @apply bg-amber-500;
+}

--- a/packages/nextjs/app/admin/_components/submission-rating.css
+++ b/packages/nextjs/app/admin/_components/submission-rating.css
@@ -1,20 +1,8 @@
-.rating input:checked ~ input,
-.rating input[aria-checked="true"] ~ input {
-    --tw-bg-opacity: 1;
-}
-
 .rating:hover .star {
     @apply bg-amber-500;
 }
 
-.rating:hover .star.peer:hover ~ .peer-hover\:bg-gray-400 {
-    @apply bg-gray-400;
-}
-
-.rating input[type=radio]:checked {
+.rating:hover .star.peer:hover ~ .peer-hover\:bg-amber-400 {
     @apply bg-amber-500;
-}
-
-.rating *:has(+ input[type=radio]:checked) {
-    @apply bg-amber-500;
+    @apply bg-opacity-20;
 }

--- a/packages/nextjs/app/admin/_components/submission-rating.css
+++ b/packages/nextjs/app/admin/_components/submission-rating.css
@@ -1,8 +1,11 @@
+.rating .rating-hidden  {
+    @apply w-0;
+}
+
 .rating:hover .star {
     @apply bg-amber-500;
 }
 
 .rating:hover .star.peer:hover ~ .peer-hover\:bg-amber-400 {
-    @apply bg-amber-500;
-    @apply bg-opacity-20;
+    @apply bg-amber-500 bg-opacity-20;
 }


### PR DESCRIPTION
## Description

- Style the rating stars on the admin page, adding a hover effect.
- Add the count to the `Not Voted` and `Voted` tabs.
- Adjust the card colors, so the new star color shows up better.