### PR TITLE
Add env var logic for Submissions and Voting processes and explain on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ yarn start
 
 Visit your app on: `http://localhost:3000`.
 
+## Enabling Submissions and Voting
+
+Submission and Voting processes are disabled by default.
+
+To enable the features, you need to set the following environment variables:
+
+- `NEXT_PUBLIC_SUBMISSIONS_ENABLED`: Set to `true` to enable submissions
+- `NEXT_PUBLIC_VOTING_ENABLED`: Set to `true` to enable voting
+
+You can set these variables in your `.env.local` file for local development:
+
+```
+NEXT_PUBLIC_SUBMISSIONS_ENABLED=true
+NEXT_PUBLIC_VOTING_ENABLED=true
+```
+
+For production, set these variables in your hosting provider's environment configuration.
+
+If you want to change this default behavior, you can modify the logic in your scaffold config file located at `packages/nextjs/scaffold.config.ts`. Look for the `submissionsEnabled` and `votingEnabled` properties in the `scaffoldConfig` object.
+
 ## Database (dev info)
 
 We are using Drizzle with Postgres. You can run `drizzle-kit` from the root with `yarn drizzle-kit`

--- a/packages/nextjs/.env.example
+++ b/packages/nextjs/.env.example
@@ -11,3 +11,5 @@
 # More info: https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables
 NEXT_PUBLIC_ALCHEMY_API_KEY=
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=
+NEXT_PUBLIC_SUBMISSIONS_ENABLED=
+NEXT_PUBLIC_VOTING_ENABLED=

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -36,10 +36,10 @@ const scaffoldConfig = {
   onlyLocalBurnerWallet: true,
 
   // Enable submissions
-  submissionsEnabled: false,
+  submissionsEnabled: process.env.NEXT_PUBLIC_SUBMISSIONS_ENABLED === "true" || false,
 
   // Enable voting on submissions
-  votingEnabled: false,
+  votingEnabled: process.env.NEXT_PUBLIC_VOTING_ENABLED === "true" || false,
 
   // Score threshold for winners and runners up
   winnersThreshold: 7,


### PR DESCRIPTION
Remains `false` by default, users can either (explained on Readme):

- Set the ENV var to `true`
- Change the default logic in their `packages/nextjs/scaffold.config.ts` 

Closes #79 