### PR TITLE
Add new "All submissions" tab to /admin view

### DIFF
--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -13,7 +13,7 @@ import { SubmissionWithAvg } from "~~/services/database/repositories/submissions
 import { postMutationFetcher } from "~~/utils/react-query";
 import { notification } from "~~/utils/scaffold-eth";
 
-export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }) => {
+export const SubmissionCard = ({ submission, tabName }: { submission: SubmissionWithAvg; tabName: string }) => {
   const { votingEnabled } = scaffoldConfig;
   const { address: connectedAddress } = useAccount();
 
@@ -91,8 +91,8 @@ export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }
           <div className="rating flex items-center">
             <input
               type="radio"
-              id={`rating_${submission.id}_0`}
-              name={`rating_${submission.id}`}
+              id={`rating_${tabName}_${submission.id}_0`}
+              name={`rating_${tabName}_${submission.id}`}
               className="rating-hidden"
               checked={score === 0}
               onChange={() => vote(0)}
@@ -100,7 +100,7 @@ export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }
             {[...Array(10)].map((_e, i) => (
               <input
                 type="radio"
-                name={`rating_${submission.id}`}
+                name={`rating_${tabName}_${submission.id}`}
                 className="mask mask-star-2 star bg-amber-500 peer peer-hover:bg-amber-400 disabled:bg-gray-200 disabled:pointer-events-none"
                 title={(i + 1).toString()}
                 checked={score === i + 1}
@@ -116,7 +116,7 @@ export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }
               className={clsx("ml-auto cursor-pointer underline text-sm hover:no-underline", {
                 "text-gray-400 cursor-not-allowed": isVotePending,
               })}
-              htmlFor={`rating_${submission.id}_0`}
+              htmlFor={`rating_${tabName}_${submission.id}_0`}
             >
               Clear
             </label>

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -97,15 +97,19 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           </div>
         </div>
 
-        {/* New All Submissions Tab */}
+        {/* All Submissions Tab */}
         <input type="radio" name="submission_tabs" role="tab" className="tab whitespace-nowrap" aria-label={allLabel} />
         <div role="tabpanel" className="tab-content py-6">
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {all
-              .sort((a, b) => b.avgScore - a.avgScore)
-              .map(submission => (
-                <SubmissionCard key={submission.id} submission={submission} tabName="all" />
-              ))}
+            {all.length === 0 ? (
+              <div role="alert" className="alert col-span-2">
+                <span>There are no submissions yet.</span>
+              </div>
+            ) : (
+              all
+                .sort((a, b) => b.avgScore - a.avgScore)
+                .map(submission => <SubmissionCard key={submission.id} submission={submission} tabName="all" />)
+            )}
           </div>
         </div>
       </div>

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -9,9 +9,8 @@ const skeletonClasses = "animate-pulse bg-gray-200 rounded-none w-full h-96";
 export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) => {
   const { address: connectedAddress } = useAccount();
 
-  const { voted, notVoted } = submissions.reduce(
+  const { voted, notVoted, all } = submissions.reduce(
     (acc, submission) => {
-      // Connected address has voted
       const currentVote = submission.votes.find(vote => vote.builder === connectedAddress);
 
       const avgScore =
@@ -20,6 +19,8 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           : 0;
 
       const submissionWithAvg = { ...submission, avgScore };
+
+      acc.all.push(submissionWithAvg);
 
       if (currentVote) {
         acc.voted.push(submissionWithAvg);
@@ -32,15 +33,18 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
     {
       voted: [] as SubmissionWithAvg[],
       notVoted: [] as SubmissionWithAvg[],
+      all: [] as SubmissionWithAvg[],
     },
   );
 
   const votedLabel = connectedAddress ? `Voted (${voted.length})` : "Voted (-)";
   const notVotedLabel = connectedAddress ? `Not Voted (${notVoted.length})` : "Not Voted (-)";
+  const allLabel = `All Submissions (${all.length})`;
 
   return (
     <div className="max-w-7xl container mx-auto px-6">
       <div role="tablist" className="tabs tabs-bordered tabs-lg">
+        {/* Not Voted Tab */}
         <input
           type="radio"
           name="submission_tabs"
@@ -59,7 +63,7 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
               </>
             ) : (
               notVoted.map(submission => {
-                return <SubmissionCard key={submission.id} submission={submission} />;
+                return <SubmissionCard key={submission.id} submission={submission} tabName="notVoted" />;
               })
             )}
             {notVoted.length === 0 && (
@@ -70,6 +74,7 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           </div>
         </div>
 
+        {/* Voted Tab */}
         <input
           type="radio"
           name="submission_tabs"
@@ -87,8 +92,20 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
             {voted
               .sort((a, b) => b.avgScore - a.avgScore)
               .map(submission => {
-                return <SubmissionCard key={submission.id} submission={submission} />;
+                return <SubmissionCard key={submission.id} submission={submission} tabName="voted" />;
               })}
+          </div>
+        </div>
+
+        {/* New All Submissions Tab */}
+        <input type="radio" name="submission_tabs" role="tab" className="tab whitespace-nowrap" aria-label={allLabel} />
+        <div role="tabpanel" className="tab-content py-6">
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {all
+              .sort((a, b) => b.avgScore - a.avgScore)
+              .map(submission => (
+                <SubmissionCard key={submission.id} submission={submission} tabName="all" />
+              ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Added a new tab to /admin. In this new tab we'll see all submissions, ordered by avg. result. Will be useful also for #81 because this will be the only tab where admins will check the results. 

I have named it "All Submissions" but can rename to "Results" if we prefer it. Went for "All Submissions" because admins can vote also directly from that view, it's not read-only, but I guess Results could work also even if it's read mode.

Closes #80 