### PR TITLE
Add "voter" role to /admin

### DIFF
--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -55,6 +55,8 @@ export const SubmissionCard = ({ submission, tabName }: { submission: Submission
 
   const telegramUser = submission.telegram?.replace("@", "");
 
+  const showResults = tabName === "all";
+
   return (
     <div key={submission.id} className="card bg-base-200 text-secondary-content border border-gray-300 rounded-none">
       <SubmissionEligible submission={submission} />
@@ -124,10 +126,16 @@ export const SubmissionCard = ({ submission, tabName }: { submission: Submission
         </div>
 
         <div className="mt-3 flex items-center justify-between">
-          <div className="badge badge-accent flex flex-col shrink-0 p-8 border border-accent-content">
-            <div className="text-2xl font-bold">{scoreAvg}</div>
-            <div>{submission.votes.length} votes</div>
-          </div>
+          {showResults ? (
+            <div className="badge badge-accent flex flex-col shrink-0 p-8 border border-accent-content">
+              <div className="text-2xl font-bold">{scoreAvg}</div>
+              <div>{submission.votes.length} votes</div>
+            </div>
+          ) : (
+            <div className="badge badge-accent flex flex-col shrink-0 p-8 border border-accent-content">
+              <div>{submission.votes.length} votes</div>
+            </div>
+          )}
           <SubmissionComments submission={submission} />
         </div>
       </div>

--- a/packages/nextjs/app/admin/_components/SubmissionCard.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionCard.tsx
@@ -13,7 +13,7 @@ import { SubmissionWithAvg } from "~~/services/database/repositories/submissions
 import { postMutationFetcher } from "~~/utils/react-query";
 import { notification } from "~~/utils/scaffold-eth";
 
-export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }) => {
+export const SubmissionCard = ({ submission, tabName }: { submission: SubmissionWithAvg; tabName: string }) => {
   const { votingEnabled } = scaffoldConfig;
   const { address: connectedAddress } = useAccount();
 
@@ -91,8 +91,8 @@ export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }
           <div className="rating flex items-center">
             <input
               type="radio"
-              id={`rating_${submission.id}_0`}
-              name={`rating_${submission.id}`}
+              id={`rating_${tabName}_${submission.id}_0`}
+              name={`rating_${tabName}_${submission.id}`}
               className="rating-hidden"
               checked={score === 0}
               onChange={() => vote(0)}
@@ -100,7 +100,7 @@ export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }
             {[...Array(10)].map((_e, i) => (
               <input
                 type="radio"
-                name={`rating_${submission.id}`}
+                name={`rating_${tabName}_${submission.id}`}
                 className="mask mask-star-2 star bg-amber-500 peer peer-hover:bg-amber-400 disabled:bg-gray-200 disabled:pointer-events-none"
                 title={(i + 1).toString()}
                 checked={score === i + 1}
@@ -116,7 +116,7 @@ export const SubmissionCard = ({ submission }: { submission: SubmissionWithAvg }
               className={clsx("ml-auto cursor-pointer underline text-sm hover:no-underline", {
                 "text-gray-400 cursor-not-allowed": isVotePending,
               })}
-              htmlFor={`rating_${submission.id}_0`}
+              htmlFor={`rating_${tabName}_${submission.id}_0`}
             >
               Clear
             </label>

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -87,9 +87,15 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
         />
         <div role="tabpanel" className="tab-content py-6">
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {voted.map(submission => (
-              <SubmissionCard key={submission.id} submission={submission} tabName="voted" />
-            ))}
+            {voted.length === 0 ? (
+              <div role="alert" className="alert col-span-2">
+                <span>You have not voted on any submissions yet.</span>
+              </div>
+            ) : (
+              voted
+                .sort((a, b) => b.avgScore - a.avgScore)
+                .map(submission => <SubmissionCard key={submission.id} submission={submission} tabName="voted" />)
+            )}
           </div>
         </div>
 
@@ -105,11 +111,15 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
             />
             <div role="tabpanel" className="tab-content py-6">
               <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-                {all
-                  .sort((a, b) => b.avgScore - a.avgScore)
-                  .map(submission => (
-                    <SubmissionCard key={submission.id} submission={submission} tabName="all" />
-                  ))}
+                {all.length === 0 ? (
+                  <div role="alert" className="alert col-span-2">
+                    <span>There are no submissions yet.</span>
+                  </div>
+                ) : (
+                  all
+                    .sort((a, b) => b.avgScore - a.avgScore)
+                    .map(submission => <SubmissionCard key={submission.id} submission={submission} tabName="all" />)
+                )}
               </div>
             </div>
           </>

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -9,9 +9,8 @@ const skeletonClasses = "animate-pulse bg-gray-200 rounded-none w-full h-96";
 export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) => {
   const { address: connectedAddress } = useAccount();
 
-  const { voted, notVoted } = submissions.reduce(
+  const { voted, notVoted, all } = submissions.reduce(
     (acc, submission) => {
-      // Connected address has voted
       const currentVote = submission.votes.find(vote => vote.builder === connectedAddress);
 
       const avgScore =
@@ -20,6 +19,8 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           : 0;
 
       const submissionWithAvg = { ...submission, avgScore };
+
+      acc.all.push(submissionWithAvg);
 
       if (currentVote) {
         acc.voted.push(submissionWithAvg);
@@ -32,15 +33,18 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
     {
       voted: [] as SubmissionWithAvg[],
       notVoted: [] as SubmissionWithAvg[],
+      all: [] as SubmissionWithAvg[],
     },
   );
 
   const votedLabel = connectedAddress ? `Voted (${voted.length})` : "Voted (-)";
   const notVotedLabel = connectedAddress ? `Not Voted (${notVoted.length})` : "Not Voted (-)";
+  const allLabel = `All Submissions (${all.length})`;
 
   return (
     <div className="max-w-7xl container mx-auto px-6">
       <div role="tablist" className="tabs tabs-bordered tabs-lg">
+        {/* Not Voted Tab */}
         <input
           type="radio"
           name="submission_tabs"
@@ -59,7 +63,7 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
               </>
             ) : (
               notVoted.map(submission => {
-                return <SubmissionCard key={submission.id} submission={submission} />;
+                return <SubmissionCard key={submission.id} submission={submission} tabName="notVoted" />;
               })
             )}
             {notVoted.length === 0 && (
@@ -70,6 +74,7 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
           </div>
         </div>
 
+        {/* Voted Tab */}
         <input
           type="radio"
           name="submission_tabs"
@@ -87,8 +92,20 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
             {voted
               .sort((a, b) => b.avgScore - a.avgScore)
               .map(submission => {
-                return <SubmissionCard key={submission.id} submission={submission} />;
+                return <SubmissionCard key={submission.id} submission={submission} tabName="voted" />;
               })}
+          </div>
+        </div>
+
+        {/* New All Submissions Tab */}
+        <input type="radio" name="submission_tabs" role="tab" className="tab whitespace-nowrap" aria-label={allLabel} />
+        <div role="tabpanel" className="tab-content py-6">
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {all
+              .sort((a, b) => b.avgScore - a.avgScore)
+              .map(submission => (
+                <SubmissionCard key={submission.id} submission={submission} tabName="all" />
+              ))}
           </div>
         </div>
       </div>

--- a/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
+++ b/packages/nextjs/app/admin/_components/SubmissionTabs.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { SubmissionCard } from "./SubmissionCard";
+import { useSession } from "next-auth/react";
 import { useAccount } from "wagmi";
 import { Submission, SubmissionWithAvg } from "~~/services/database/repositories/submissions";
 
 const skeletonClasses = "animate-pulse bg-gray-200 rounded-none w-full h-96";
 
 export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) => {
+  const { data: session } = useSession();
+  const isAdmin = session?.user?.role === "admin";
+
   const { address: connectedAddress } = useAccount();
 
   const { voted, notVoted, all } = submissions.reduce(
@@ -61,15 +65,14 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
                 <div className={skeletonClasses}></div>
                 <div className={skeletonClasses}></div>
               </>
-            ) : (
-              notVoted.map(submission => {
-                return <SubmissionCard key={submission.id} submission={submission} tabName="notVoted" />;
-              })
-            )}
-            {notVoted.length === 0 && (
+            ) : notVoted.length === 0 ? (
               <div role="alert" className="alert col-span-2">
                 <span>There are no submissions to vote on.</span>
               </div>
+            ) : (
+              notVoted.map(submission => (
+                <SubmissionCard key={submission.id} submission={submission} tabName="notVoted" />
+              ))
             )}
           </div>
         </div>
@@ -84,30 +87,33 @@ export const SubmissionTabs = ({ submissions }: { submissions: Submission[] }) =
         />
         <div role="tabpanel" className="tab-content py-6">
           <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {voted.length === 0 && (
-              <div role="alert" className="alert col-span-2">
-                <span>You have not voted on any submissions yet.</span>
-              </div>
-            )}
-            {voted
-              .sort((a, b) => b.avgScore - a.avgScore)
-              .map(submission => {
-                return <SubmissionCard key={submission.id} submission={submission} tabName="voted" />;
-              })}
+            {voted.map(submission => (
+              <SubmissionCard key={submission.id} submission={submission} tabName="voted" />
+            ))}
           </div>
         </div>
 
-        {/* New All Submissions Tab */}
-        <input type="radio" name="submission_tabs" role="tab" className="tab whitespace-nowrap" aria-label={allLabel} />
-        <div role="tabpanel" className="tab-content py-6">
-          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {all
-              .sort((a, b) => b.avgScore - a.avgScore)
-              .map(submission => (
-                <SubmissionCard key={submission.id} submission={submission} tabName="all" />
-              ))}
-          </div>
-        </div>
+        {/* All Submissions Tab (only for admins) */}
+        {isAdmin && (
+          <>
+            <input
+              type="radio"
+              name="submission_tabs"
+              role="tab"
+              className="tab whitespace-nowrap"
+              aria-label={allLabel}
+            />
+            <div role="tabpanel" className="tab-content py-6">
+              <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+                {all
+                  .sort((a, b) => b.avgScore - a.avgScore)
+                  .map(submission => (
+                    <SubmissionCard key={submission.id} submission={submission} tabName="all" />
+                  ))}
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -15,7 +15,7 @@ const Admin: NextPage = async () => {
     );
   }
 
-  if (session?.user?.role !== "admin" && session?.user?.role !== "voter") {
+  if (!session?.user?.voter) {
     return <div className="flex items-center text-xl flex-col flex-grow pt-10 space-y-4">Access denied</div>;
   }
 

--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -15,7 +15,7 @@ const Admin: NextPage = async () => {
     );
   }
 
-  if (session?.user?.role !== "admin") {
+  if (session?.user?.role !== "admin" && session?.user?.role !== "voter") {
     return <div className="flex items-center text-xl flex-col flex-grow pt-10 space-y-4">Access denied</div>;
   }
 

--- a/packages/nextjs/app/api/submissions/[submissionId]/comments/route.ts
+++ b/packages/nextjs/app/api/submissions/[submissionId]/comments/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: NextRequest, { params }: { params: { submissionI
   try {
     const session = await getServerSession(authOptions);
 
-    if (session?.user.role !== "admin") {
+    if (session?.user.role !== "admin" && session?.user.role !== "voter") {
       return NextResponse.json({ error: "Only admins can add comments" }, { status: 401 });
     }
     const { submissionId } = params;

--- a/packages/nextjs/app/api/submissions/[submissionId]/comments/route.ts
+++ b/packages/nextjs/app/api/submissions/[submissionId]/comments/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: NextRequest, { params }: { params: { submissionI
   try {
     const session = await getServerSession(authOptions);
 
-    if (session?.user.role !== "admin" && session?.user.role !== "voter") {
+    if (!session?.user.voter) {
       return NextResponse.json({ error: "Only admins can add comments" }, { status: 401 });
     }
     const { submissionId } = params;

--- a/packages/nextjs/app/api/submissions/[submissionId]/eligible/route.ts
+++ b/packages/nextjs/app/api/submissions/[submissionId]/eligible/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: NextRequest, { params }: { params: { submissionI
   try {
     const session = await getServerSession(authOptions);
 
-    if (session?.user.role !== "admin" && session?.user.role !== "voter") {
+    if (!session?.user.voter) {
       return NextResponse.json({ error: "Only admins can set eligible" }, { status: 401 });
     }
     const { submissionId } = params;

--- a/packages/nextjs/app/api/submissions/[submissionId]/eligible/route.ts
+++ b/packages/nextjs/app/api/submissions/[submissionId]/eligible/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: NextRequest, { params }: { params: { submissionI
   try {
     const session = await getServerSession(authOptions);
 
-    if (session?.user.role !== "admin") {
+    if (session?.user.role !== "admin" && session?.user.role !== "voter") {
       return NextResponse.json({ error: "Only admins can set eligible" }, { status: 401 });
     }
     const { submissionId } = params;

--- a/packages/nextjs/app/api/submissions/[submissionId]/votes/route.ts
+++ b/packages/nextjs/app/api/submissions/[submissionId]/votes/route.ts
@@ -9,7 +9,7 @@ export async function POST(req: NextRequest, { params }: { params: { submissionI
   try {
     const session = await getServerSession(authOptions);
 
-    if (session?.user.role !== "admin" && session?.user.role !== "voter") {
+    if (!session?.user.voter) {
       return NextResponse.json({ error: "Only admins and voters can vote" }, { status: 401 });
     }
 

--- a/packages/nextjs/app/api/submissions/[submissionId]/votes/route.ts
+++ b/packages/nextjs/app/api/submissions/[submissionId]/votes/route.ts
@@ -9,8 +9,8 @@ export async function POST(req: NextRequest, { params }: { params: { submissionI
   try {
     const session = await getServerSession(authOptions);
 
-    if (session?.user.role !== "admin") {
-      return NextResponse.json({ error: "Only admins can vote" }, { status: 401 });
+    if (session?.user.role !== "admin" && session?.user.role !== "voter") {
+      return NextResponse.json({ error: "Only admins and voters can vote" }, { status: 401 });
     }
 
     if (!votingEnabled) {

--- a/packages/nextjs/services/database/seed.ts
+++ b/packages/nextjs/services/database/seed.ts
@@ -29,6 +29,7 @@ async function seed() {
     .values([
       { id: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", role: "admin" },
       { id: "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", role: "user" },
+      { id: "0x08fc7400ba37fc4ee1bf73bed5ddcb5db6a1036a", role: "voter" },
     ])
     .execute();
 

--- a/packages/nextjs/types/next-auth/next-auth.d.ts
+++ b/packages/nextjs/types/next-auth/next-auth.d.ts
@@ -7,6 +7,7 @@ declare module "next-auth" {
     user: {
       address?: string | null;
       role?: string | null;
+      voter?: boolean;
     };
     expires: ISODateString;
   }

--- a/packages/nextjs/utils/auth.ts
+++ b/packages/nextjs/utils/auth.ts
@@ -72,6 +72,7 @@ export const authOptions: AuthOptions = {
     async session({ session, token }: { session: Session; token: JWT }) {
       session.user.address = token.sub;
       session.user.role = token.role;
+      session.user.voter = token.role ? ["admin", "voter"].includes(token.role) : false;
       return session;
     },
   },


### PR DESCRIPTION
Adding a new "voter" role, to act as "Guest voter", so we can add anyone to vote on Hackathon submissions, but they can't see other voter results, so they can't check the winners either.

- Added new "voter" role checks in database (needs to be able to vote, to comment and to mark as eligible or not eligible)
- Remove results from "Not Voted" and "Voted" tabs
- Add "admin" check for "All Submissions" tab
- Adds new dummy voter to seed script

Admins can choose to know or not know the current avg. score, they can blind vote from "Not Voted" or they can choose to vote from All Submissions to have extra info.

Closes #81 